### PR TITLE
Update resume content for Levvels role

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,60 +1,66 @@
 {
-  "name": "Kh.Kim",
-  "summary": "Hello, I am Kihwan Kim. Currently, I am a Frontend Engineer at unicorn startup RIDI, boasting over 7 years of industry and academic experience. For the last 3 years, my focus has been exclusively on front-end development. Before that, I dedicated 4 years to researching two key topics: visual analytics for explaining machine learning models and AI-driven user interfaces.",
+  "name": "Kihwan Kim",
+  "summary": "I'm Kihwan Kim, a Frontend Engineer working at Levvels and formerly at RIDI, focusing on large-scale web architecture improvements and interaction optimization. My academic background is in Visual Analytics and AI-driven Interfaces, and I integrate that research-oriented mindset into building flexible and scalable user experiences. Having worked across both industry and academia, I value not only technical precision but also balanced collaboration and thoughtful problem definition.",
   "present": "Present",
   "company": {
-    "ridi": {
-      "name": "RIDI Corporation",
+    "levvels": {
+      "name": "Levvels",
       "position": "Frontend Engineer",
+      "period": "Jul 2025–Present",
+      "extra": "Officially Levvels Inc. (pronounced ‘Levels’)",
       "projects": [
         {
-          "title": "RIDI website",
-          "period": "2022.05-Present",
-          "description": "I develop the frontend of a content platform that provides webtoons, web novels, comics, and e-books.",
+          "title": "New Commerce Platform Frontend",
+          "period": "Jul 2025–Present",
+          "description": "Designing and delivering the end-to-end frontend for Levvels’ commerce experience.",
           "points": [
-            "Co-architected 'RiGrid', a server-driven UI system enabling layout flexibility, content-level control, and experimental branching",
-            "Improved structure to support app-update-free UI deployments, accelerating experiment velocity by over 50%",
-            "Established a consistent rendering pipeline using GraphQL BFF and async components across platforms",
-            "Implemented new features to meet various business requirements",
-            "Maintained existing systems: refactoring, writing test codes"
+            "Developing and maintaining the entire frontend for the new commerce platform",
+            "Implemented the shopping cart system and API integration architecture",
+            "Integrated Amplitude and ChannelTalk for user behavior analytics and communication tracking",
+            "Refactored authentication flow for simplified login/signup and improved maintainability",
+            "Built PC layout design and standardized animations & transitions (mdc rules within the design system)",
+            "Developed creator channel home & post features — SNS-style posts, linked products, and editor preview (iframe-based)"
           ],
-          "badges": [
-            "Next.js",
-            "TypeScript",
-            "React",
-            "Emotion",
-            "Jest",
-            "PHP",
-            "Twig"
-          ]
+          "badges": ["React", "Next.js", "TypeScript", "Emotion", "Zustand", "Framer Motion"]
+        }
+      ]
+    },
+    "ridi": {
+      "name": "RIDI Corporation",
+      "position": "Frontend Developer",
+      "period": "May 2022–Jun 2025",
+      "projects": [
+        {
+          "title": "RIDI Webtoon, Web Novel & Ebook Platform",
+          "period": "May 2022–Jun 2025",
+          "description": "Led frontend development and operations for RIDI’s content platform.",
+          "points": [
+            "Developed and maintained the frontend for RIDI’s webtoon, web novel, and ebook platform",
+            "Co-designed and implemented the server-driven UI system 'RiGrid'",
+            "Enabled UI updates without app releases, improving content experiment speed by over 50%",
+            "Built GraphQL-based BFF and asynchronous rendering components for platform consistency",
+            "Performed refactoring and wrote test code for long-term maintainability"
+          ],
+          "badges": ["React", "TypeScript", "Next.js", "Emotion", "Jest", "PHP", "Twig"]
         }
       ]
     },
     "tmax": {
-      "name": ["Tmax Enterprise", "Currently TmaxBizAI", "Formerly TmaxData"],
-      "position": "Researcher",
+      "name": ["TmaxEnterprise", "Now TmaxBizAI", "Formerly TmaxData"],
+      "position": "Research Engineer",
+      "period": "Feb 2020–Apr 2022",
       "projects": [
         {
-          "title": "React Porting of Legacy System",
-          "period": "2021.01–2022.04",
-          "description": "Converted products implemented with a jQuery-based internal frontend library — TOP (Tmax One Platform) to React.",
+          "title": "AutoML Platform & XAI Research",
+          "period": "Feb 2020–Apr 2022",
+          "description": "Researched and built AutoML and explainable AI tooling for enterprise users.",
           "points": [
-            "Divided inadequately modularized existing code into appropriate modules and improved interfaces",
-            "Developed various new components"
+            "Developed AutoML platform and explainable AI (XAI) systems",
+            "Implemented a codeless machine learning studio for non-experts",
+            "Built visual dashboards for model training and operation",
+            "Migrated legacy jQuery-based UI to React with modular component design"
           ],
-          "badges": ["TypeScript", "React", "Sass", "Material-UI", "jQuery"]
-        },
-        {
-          "title": "AutoML Platform",
-          "period": "2020.02–2022.04",
-          "description": "Developed a platform that automates repetitive and tedious machine learning model development tasks.",
-          "points": [
-            "Implemented a codeless development studio environment for non-experts",
-            "Researched and developed explainable AI — XAI (eXplainable Artificial Intelligence) technologies",
-            "Studied interfaces for effective interaction between AutoML engines and model developers",
-            "Developed a dashboard for the development, management, and operation of machine learning models"
-          ],
-          "badges": ["TypeScript", "React", "Sass", "Material-UI", "Python"]
+          "badges": ["React", "TypeScript", "Sass", "Material-UI", "Python"]
         }
       ]
     }
@@ -64,36 +70,25 @@
       "institution": "Ulsan National Institute of Science and Technology (UNIST)",
       "degrees": [
         {
-          "degree": "Master of Science in Computer Science",
-          "period": "2018.03–2020.02"
+          "degree": "M.S. in Computer Science and Engineering",
+          "period": "Mar 2018–Feb 2020"
         },
         {
-          "degree": "Bachelor of Science in Technology Management (Multi-disciplinary major in Computer Science)",
-          "period": "2013.03–2018.02"
+          "degree": "B.S. in Technology Management with a Convergence Major in Computer Science",
+          "period": "Mar 2013–Feb 2018"
         }
       ],
       "projects": [
         {
-          "title": "AI-centered UI/UX Design",
-          "period": "2019.01–2020.02",
-          "description": "Conducted research to answer the question, 'How should the UI be designed to better collect user preference data?'",
+          "title": "Visual Analytics & AI-driven Interface Research",
+          "period": "Mar 2018–Feb 2020",
+          "description": "Researched visual analytics and AI-centric interface design for complex data experiences.",
           "points": [
-            "Measured the impact of transparency on data quality in the explore-exploit problem of recommendation systems",
-            "Proposed a metric to evaluate the value of user logs from an AI perspective",
-            "Implemented a web-based movie recommendation system for experimental environments"
+            "Analyzed how transparency in recommendation exploration affects data quality",
+            "Built experimental systems and collected real-world user logs",
+            "Explored AI-driven UX methodologies for adaptive interfaces"
           ],
-          "badges": ["Python", "Flask", "Surprise", "jQuery"]
-        },
-        {
-          "title": "Modeling Web User Behavior",
-          "period": "2019.02–2020.02",
-          "description": "Conducted research to understand and model user behavior patterns in web environments.",
-          "points": [
-            "Estimated user reward functions from behavior logs through Inverse Reinforcement Learning",
-            "Dealt with various web environments such as data analysis tools like Tableau, history education tools based on Wikipedia documents, and card games",
-            "Utilized data analysis tools such as Tableau and implemented a history education tool based on Wikipedia documents"
-          ],
-          "badges": ["Python", "TensorFlow", "Keras", "scikit-learn"]
+          "badges": ["Python", "Flask", "TensorFlow", "Keras", "scikit-learn"]
         }
       ]
     }
@@ -103,18 +98,14 @@
       "title": "An Empirical Analysis on Transparent Algorithmic Exploration in Recommender Systems",
       "uri": "https://arxiv.org/abs/2108.00151",
       "authors": ["Kihwan Kim"],
-      "conference": "A Computing Research Repository (CoRR), 2108.00151, 2021",
+      "conference": "CoRR, 2021",
       "points": [
-        "Investigated how to deliver random items to capture user preferences in recommendation systems",
-        "Implemented a web-based movie recommendation system used as an experimental environment",
-        "Proposed a metric to evaluate the value of user logs from an AI perspective",
-        "Measured the impact of transparency on data quality in the explore-exploit problem of recommendation systems",
-        "Recruited 94 participants from Amazon MTurk",
-        "Collected real usage log data and survey responses by having participants use a Netflix-like experimental environment"
+        "Analyzed how transparency in recommendation exploration affects data quality",
+        "Built an experimental web system and collected real-world user logs"
       ]
     },
     {
-      "title": "ST-GRAT: A Novel Spatio-temporal Graph Attention Networks for Accurately Forecasting Dynamically Changing Road Speed",
+      "title": "ST-GRAT: Spatio-temporal Graph Attention Networks for Forecasting Road Speed",
       "uri": "https://dl.acm.org/doi/10.1145/3340531.3411940",
       "authors": [
         "Cheonbok Park",
@@ -126,20 +117,13 @@
         "Sungahn Ko",
         "Jaegul Choo"
       ],
-      "conference": "ACM International Conference on Information and Knowledge Management (CIKM), 2020",
-      "points": [
-        "Preprocessed vehicle detection sensor data installed on the road surface by Korea Expressway Corporation",
-        "Categorized cases where attention worked effectively by patterns"
-      ]
+      "conference": "ACM CIKM, 2020"
     },
     {
-      "title": "Modeling Exploration/Exploitation Decisions through Mobile Sensing for Understanding Mechanisms of Addiction",
+      "title": "Modeling Exploration/Exploitation Decisions through Mobile Sensing",
       "uri": "https://dl.acm.org/citation.cfm?doid=3307334.3328599",
       "authors": ["Kihwan Kim", "Sanghoon Kim", "Chunggi Lee", "Sungahn Ko"],
-      "conference": "ACM International Conference on Mobile Systems, Applications, and Services (MobiSys), 2019",
-      "points": [
-        "Proposed a system to detect addiction disorders from smartphone usage logs through Inverse Reinforcement Learning"
-      ]
+      "conference": "ACM MobiSys, 2019"
     },
     {
       "title": "An Empirical Study on the Relationship Between the Number of Coordinated Views and Visual Analysis",
@@ -154,22 +138,7 @@
         "Bum Chul Kwon",
         "Sungahn Ko"
       ],
-      "conference": "A Computing Research Repository (CoRR), 2204.09524, 2018",
-      "points": [
-        "Conducted experiments to see how the number of visualization charts affects data visual analysis",
-        "Had 44 participants use a visual analysis tool and solve data analysis tasks",
-        "Categorized users' analysis patterns through think-aloud protocol, recorded screens, and log data",
-        "Observed a positive correlation between the number of charts and task scores"
-      ]
-    },
-    {
-      "title": "A Survey of Visualization Techniques for Interpreting Deep Learning",
-      "uri": "http://www.dbpia.co.kr/journal/articleDetail?nodeId=NODE07266060&language=ko_KR",
-      "authors": ["Jaesung Lee", "Kihwan Kim", "Chunggi Lee", "Sungahn Ko"],
-      "conference": "Noise & Vibration, Vol.27 No.6, 2017.11",
-      "points": [
-        "Summarized and investigated visualization techniques for interpreting deep learning models"
-      ]
+      "conference": "CoRR, 2018"
     }
   ]
 }

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -1,32 +1,47 @@
 {
   "name": "김기환",
-  "summary": "반갑습니다, 김기환입니다. 현재 유니콘 스타트업 RIDI에서 프론트엔드 엔지니어로 근무하고 있으며, 산업 및 학계에서 7년 이상의 경력을 보유하고 있습니다. 지난 3년 동안은 프론트엔드 개발에 전념해왔습니다. 그 이전 4년 동안은 머신러닝 모델을 설명하기 위한 시각적 분석 도구와 AI 기반 사용자 인터페이스라는 두 가지 주제를 연구했습니다.",
+  "summary": "프론트엔드 엔지니어 김기환입니다. Levvels와 리디(RIDI)에서 대규모 웹 서비스의 구조적 개선과 사용자 인터랙션 최적화를 담당하고 있습니다. 석사 과정에서는 시각적 데이터 탐색(Visual Analytics)과 AI 기반 인터페이스 연구를 수행했으며, 현재는 그 연구적 사고를 실무 개발에 접목해 유연하고 확장 가능한 사용자 경험을 만드는 데 집중하고 있습니다. 산업과 학계를 넘나들며 쌓은 경험을 통해, 기술적 완성도뿐 아니라 협업과 문제 정의 과정에서도 균형 있는 관점을 지니고 있습니다.",
   "present": "현재",
   "company": {
-    "ridi": {
-      "name": "리디주식회사",
-      "position": "프론트엔드 개발자",
+    "levvels": {
+      "name": "Levvels",
+      "position": "프론트엔드 엔지니어",
+      "period": "2025.07–현재",
+      "extra": "Levvels Inc. · 레벨스",
       "projects": [
         {
-          "title": "리디 웹사이트",
-          "period": "2022.05-현재",
-          "description": "웹툰, 웹소설, 만화, 전자책 등을 서비스하는 콘텐츠 플랫폼의 프론트엔드를 개발합니다.",
+          "title": "신규 커머스 플랫폼 프론트엔드 구축",
+          "period": "2025.07–현재",
+          "description": "Levvels 커머스 서비스의 프론트엔드 전반을 설계하고 개발합니다.",
           "points": [
-            "서버 중심 UI 시스템 'RiGrid' 공동 설계 및 개발 — 실험 그룹 분기, 콘텐츠 동적 변경, 유연한 레이아웃 구성을 지원",
-            "앱 업데이트 없이 UI 수정이 가능하도록 구조 개선하여, 콘텐츠 운영팀의 실험 속도 50% 이상 향상",
-            "GraphQL 기반 BFF, 비동기 렌더링 컴포넌트 설계 등으로 플랫폼 일관성 확보",
-            "비즈니스의 다양한 요구사항에 대응하는 신규 기능 구현",
-            "기존 시스템의 유지 보수: 리팩토링, 테스트 코드 작성"
+            "신규 커머스 서비스의 프론트엔드 전반 개발 및 운영",
+            "장바구니 시스템 구현 및 API 연동 구조 설계",
+            "Amplitude·채널톡 도입으로 사용자 로그 및 커뮤니케이션 기반 개선 체계 구축",
+            "인증 시스템 리팩토링으로 로그인/회원가입 플로우 단순화 및 유지보수성 향상",
+            "PC 판형 디자인 구현 및 애니메이션·전환 표준화 — 디자인 시스템 내 mdc 규칙 정립",
+            "크리에이터용 채널 홈·포스트 기능 개발 — SNS형 포스트, 관련 상품 링크, 편집 및 미리보기(iframe 기반) 인터페이스 구축"
           ],
-          "badges": [
-            "Next.js",
-            "TypeScript",
-            "React",
-            "Emotion",
-            "Jest",
-            "PHP",
-            "Twig"
-          ]
+          "badges": ["React", "Next.js", "TypeScript", "Emotion", "Zustand", "Framer Motion"]
+        }
+      ]
+    },
+    "ridi": {
+      "name": "리디주식회사 (RIDI)",
+      "position": "프론트엔드 개발자",
+      "period": "2022.05–2025.06",
+      "projects": [
+        {
+          "title": "리디 웹툰·웹소설·전자책 플랫폼",
+          "period": "2022.05–2025.06",
+          "description": "콘텐츠 플랫폼의 프론트엔드 개발 및 운영을 담당했습니다.",
+          "points": [
+            "웹툰·웹소설·전자책 플랫폼의 프론트엔드 개발 및 운영",
+            "서버 주도형 UI 시스템 ‘RiGrid’ 공동 설계 및 개발",
+            "앱 업데이트 없이 UI 수정이 가능하도록 구조 개선 → 콘텐츠 실험 속도 50% 이상 향상",
+            "GraphQL 기반 BFF 및 비동기 렌더링 컴포넌트 설계로 플랫폼 일관성 확보",
+            "리팩토링 및 테스트 코드 작성 등 유지보수 수행"
+          ],
+          "badges": ["React", "TypeScript", "Next.js", "Emotion", "Jest", "PHP", "Twig"]
         }
       ]
     },
@@ -37,28 +52,19 @@
         "舊 티맥스데이터"
       ],
       "position": "연구원",
+      "period": "2020.02–2022.04",
       "projects": [
         {
-          "title": "레거시 시스템 리액트 포팅",
-          "period": "2021.01–2022.04",
-          "description": "jQuery 기반 사내 프론트엔드 라이브러리 — TOP(Tmax One Platform)로 구현된 제품들을 리액트로 전환하였습니다.",
-          "points": [
-            "모듈화가 미흡한 기존 코드를 용도에 맞게 분할하고 인터페이스를 개선",
-            "각종 컴포넌트 신규 개발"
-          ],
-          "badges": ["TypeScript", "React", "Sass", "Material-UI", "jQuery"]
-        },
-        {
-          "title": "AutoML 플랫폼",
+          "title": "AutoML 플랫폼 및 XAI 연구",
           "period": "2020.02–2022.04",
-          "description": "소모적이고 반복적인 기계학습 모델 개발 작업을 자동화하는 플랫폼을 개발 했습니다.",
+          "description": "AutoML 플랫폼과 설명 가능한 AI(XAI) 환경을 연구·개발했습니다.",
           "points": [
-            "비전문가를 위한 Codeless 환경의 개발 스튜디오 구현",
-            "설명 가능한 AI — XAI(eXplainable Artificial Intelligence) 기술 연구 및 개발",
-            "AutoML 엔진이 모델 개발자와 효과적으로 interaction 을 할 수 있는 인터페이스를 연구",
-            "기계학습 모델의 개발, 관리 및 운영을 위한 대시보드 개발"
+            "AutoML 플랫폼 및 설명 가능한 AI(XAI) 연구·개발",
+            "비전문가를 위한 Codeless 환경 개발 스튜디오 구현",
+            "모델 학습 과정의 시각적 인터페이스와 대시보드 개발",
+            "jQuery 기반 사내 UI를 React로 포팅하고 재사용 가능한 컴포넌트 구조 설계"
           ],
-          "badges": ["TypeScript", "React", "Sass", "Material-UI", "Python"]
+          "badges": ["React", "TypeScript", "Sass", "Material-UI", "Python"]
         }
       ]
     }
@@ -72,32 +78,21 @@
           "period": "2018.03–2020.02"
         },
         {
-          "degree": "기술경영학 학사 (컴퓨터공학 융합전공)",
+          "degree": "기술경영학부, 컴퓨터공학 융합전공 학사",
           "period": "2013.03–2018.02"
         }
       ],
       "projects": [
         {
-          "title": "AI 중심 UI/UX 설계",
-          "period": "2019.01–2020.02",
-          "description": "'어떻게 UI를 구성해야 사용자의 취향이 담긴 데이터를 더 잘 수집할 수 있을까?'라는 질문에 답하는 연구를 수행하였습니다.",
+          "title": "시각적 데이터 탐색 및 AI 중심 UI 연구",
+          "period": "2018.03–2020.02",
+          "description": "시각적 데이터 탐색(Visual Analytics)과 AI 기반 인터페이스 설계를 연구했습니다.",
           "points": [
-            "추천시스템의 Explore-Exploit 문제에서 투명성이 데이터의 품질에 미치는 영향을 측정",
-            "사용자 로그의 가치를 AI 측면에서 평가하는 metric 제안",
-            "실험 환경용 웹 기반 영화 추천 시스템 구현"
+            "추천 시스템 탐색(Exploration) 투명성이 데이터 품질에 미치는 영향 분석",
+            "사용자 로그 기반 실험 시스템 구축 및 실사용자 데이터 수집",
+            "AI 중심 UI/UX 설계 방법론 연구"
           ],
-          "badges": ["Python", "Flask", "Surprise", "jQuery"]
-        },
-        {
-          "title": "웹 사용자 행동 모델링",
-          "period": "2019.02–2020.02",
-          "description": "웹 환경에서 사용자의 행동 패턴을 파악하고 이를 모델링하는 연구를 했습니다.",
-          "points": [
-            "역강화학습 — (Inverse Reinforcement Learning) 방법론을 통해, 사용자들의 행동 이력으로 사용자의 보상 함수를 추정",
-            "Tableau와 같은 데이터 분석 도구, 위키피디아 문서 기반 역사 교육 도구, 카드 게임과 같은 다양한 웹 환경을 다룸",
-            "데이터 분석 도구인 Tableau를 활용하고, 위키피디아 문서를 기반으로 한 역사 교육 도구를 구현"
-          ],
-          "badges": ["Python", "TensorFlow", "Keras", "scikit-learn"]
+          "badges": ["Python", "Flask", "TensorFlow", "Keras", "scikit-learn"]
         }
       ]
     }
@@ -107,18 +102,14 @@
       "title": "An Empirical Analysis on Transparent Algorithmic Exploration in Recommender Systems",
       "uri": "https://arxiv.org/abs/2108.00151",
       "authors": ["김기환"],
-      "conference": "A Computing Research Repository (CoRR), 2108.00151, 2021",
+      "conference": "CoRR, 2021",
       "points": [
-        "추천 시스템에서 사용자 취향을 파악하기 위한 랜덤 아이템들을 어떻게 전달해야 할까?",
-        "실험 환경으로 사용된 웹 기반 영화 추천 시스템 구현",
-        "사용자 로그의 가치를 AI 측면에서 평가하는 metric 제안",
-        "추천시스템의 Explore-Exploit 문제에서 투명성이 데이터의 품질에 미치는 영향을 측정",
-        "Amazon MTurk에서 94명의 피험자를 구인",
-        "피험자들에게 넷플릭스와 유사한 실험 환경을 이용하도록 하여, 실사용 로그 데이터와 설문 응답을 수집"
+        "추천 시스템의 탐색(Exploration) 투명성이 데이터 품질에 미치는 영향을 분석",
+        "사용자 로그 기반 실험 시스템 구축 및 실사용자 데이터 수집"
       ]
     },
     {
-      "title": "ST-GRAT: A Novel Spatio-temporal Graph Attention Networks for Accurately Forecasting Dynamically Changing Road Speed",
+      "title": "ST-GRAT: Spatio-temporal Graph Attention Networks for Forecasting Road Speed",
       "uri": "https://dl.acm.org/doi/10.1145/3340531.3411940",
       "authors": [
         "박천복",
@@ -130,20 +121,13 @@
         "고성안",
         "주재걸"
       ],
-      "conference": "ACM International Conference on Information and Knowledge Management (CIKM), 2020",
-      "points": [
-        "한국도로공사의 도로 바닥에 설치된 차량 감지 센서 데이터를 전처리",
-        "Attention이 효과적으로 동작한 경우들을 패턴 별로 묶어 카테고리화"
-      ]
+      "conference": "ACM CIKM, 2020"
     },
     {
-      "title": "Modeling Exploration/Exploitation Decisions through Mobile Sensing for Understanding Mechanisms of Addiction",
+      "title": "Modeling Exploration/Exploitation Decisions through Mobile Sensing",
       "uri": "https://dl.acm.org/citation.cfm?doid=3307334.3328599",
       "authors": ["김기환", "김상훈", "이충기", "고성안"],
-      "conference": "ACM International Conference on Mobile Systems, Applications, and Services (MobiSys), 2019",
-      "points": [
-        "Inverse Reinforcement Learning을 통해, 스마트폰 사용 로그로 중독 질환 여부를 감지하는 시스템을 제안"
-      ]
+      "conference": "ACM MobiSys, 2019"
     },
     {
       "title": "An Empirical Study on the Relationship Between the Number of Coordinated Views and Visual Analysis",
@@ -158,20 +142,7 @@
         "권범철",
         "고성안"
       ],
-      "conference": "A Computing Research Repository (CoRR), 2204.09524, 2018",
-      "points": [
-        "시각화 차트의 갯수가 데이터의 시각적 분석에 어떤 영향을 미치는지 실험",
-        "44명 피험자에게 시각적 분석 도구를 주고, 데이터 분석 과제를 풀도록 함",
-        "Think-aloud 프로토콜과 녹화된 화면, 그리고 로그 데이터를 통해 사용자의 분석 패턴을 카테고리화",
-        "차트의 갯수와 과제 점수 간 양의 상관관계를 관찰"
-      ]
-    },
-    {
-      "title": "시각화 기반 딥러닝 분석 기술",
-      "uri": "http://www.dbpia.co.kr/journal/articleDetail?nodeId=NODE07266060&language=ko_KR",
-      "authors": ["이재성", "김기환", "이충기", "고성안"],
-      "conference": "소음진동 제27권 제6호 2017.11",
-      "points": ["딥 러닝 모델을 해석하기 위한 시각화 기법들을 정리 및 조사"]
+      "conference": "CoRR, 2018"
     }
   ]
 }

--- a/src/components/CurriculumVitae/CurriculumVitae.tsx
+++ b/src/components/CurriculumVitae/CurriculumVitae.tsx
@@ -10,6 +10,9 @@ import { Section } from '../Section';
 export function CurriculumVitae() {
   const { t } = useTranslation(['common']);
 
+  const levvelsProjects = t('company.levvels.projects', {
+    returnObjects: true,
+  }) as Project[];
   const ridiProjects = t('company.ridi.projects', {
     returnObjects: true,
   }) as Project[];
@@ -41,11 +44,22 @@ export function CurriculumVitae() {
       </Section>
       <Section title="Experience">
         <Affiliation
+          name={t('company.levvels.name')}
+          info={[
+            {
+              position: t('company.levvels.position'),
+              period: t('company.levvels.period'),
+            },
+          ]}
+          extra={t('company.levvels.extra')}
+          projectList={levvelsProjects}
+        />
+        <Affiliation
           name={t('company.ridi.name')}
           info={[
             {
               position: t('company.ridi.position'),
-              period: `2022.05-${t('present')}`,
+              period: t('company.ridi.period'),
             },
           ]}
           projectList={ridiProjects}
@@ -55,7 +69,7 @@ export function CurriculumVitae() {
           info={[
             {
               position: t('company.tmax.position'),
-              period: '2020.02–2022.04',
+              period: t('company.tmax.period'),
             },
           ]}
           extra={


### PR DESCRIPTION
## Summary
- add Levvels experience and refresh summary text in both Korean and English resume content
- update RIDI and Tmax entries with revised timelines, responsibilities, and skills
- surface the Levvels affiliation in the curriculum vitae component using localized periods and extras

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1e41756c48328befb9a47e37be8e1